### PR TITLE
Fixed typo in Bayes factor heuristics discussion

### DIFF
--- a/docs/source/notebooks/Bayes_factor.ipynb
+++ b/docs/source/notebooks/Bayes_factor.ipynb
@@ -77,7 +77,7 @@
     "* 30-100: very strong\n",
     "* $>$ 100: extreme\n",
     "\n",
-    "Notice that if you get numbers below 0 then the support is for the model in the denominator, tables for those cases are also available. Of course, you can also just take the inverse of the values in the above table or take the inverse of the BF value and you will be OK.\n",
+    "Notice that if you get numbers below 1 then the support is for the model in the denominator, tables for those cases are also available. Of course, you can also just take the inverse of the values in the above table or take the inverse of the BF value and you will be OK.\n",
     "\n",
     "Is very important to remember that these rules are just conventions, simple guides at best. Results should always be put into context of our problems and should be accompanied with enough details that others could potentially check if they agree with our conclusions. The evidence necessary to make a claim is not the same in particle physics, or a court, or to evacuate a town to prevent hundreds of deaths. "
    ]


### PR DESCRIPTION
This notebook includes suggestions on how to interpret different Bayes factors in which it mentions, "if you get numbers below 0 then the support is for the model in the denominator." Unless I am terribly mistaken, Bayes factors cannot be less than zero and Bayes factors less than one support the model in the denominator. This pull request would change the 0 to a 1.